### PR TITLE
Fix multi control

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": false,
     "currentLanguage": "java",
     "projectYear": "2023",
-    "teamNumber": 3506
+    "teamNumber": 9998
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -26,9 +26,11 @@ import frc.robot.constants.ElevatorConstants;
 import frc.robot.constants.FieldConstants;
 import frc.robot.di.DaggerRobotComponent;
 import frc.robot.di.RobotComponent;
+import frc.robot.utils.controllerUtils.Controller;
 import frc.robot.utils.rests.restUtils.RESTHandler;
 
 import javax.inject.Inject;
+import java.util.Arrays;
 import java.util.List;
 
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,10 +80,8 @@ public class RobotContainer {
     private void configureControllerOneBindings() {
         //Set up branch to add xbox commands
         buttonHelper.setController(0);
-        buttonHelper.createButton(XboxController.Button.kStart.value, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
-                .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
-        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
-        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
+
+
 
         buttonHelper.createButton(XboxController.Button.kX.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
@@ -93,16 +91,19 @@ public class RobotContainer {
 
         buttonHelper.setController(1);
 
+        buttonHelper.createButton(2, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(1, 0, new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
 
-        buttonHelper.createButton(8, 0, new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
-
-        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, armSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
-        buttonHelper.createButton(7, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
+        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
+        buttonHelper.createButton(4, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(10, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
 
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ToggleCarriagePositionCommand(carriageSubsystem, elevatorSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
+
+        buttonHelper.createButton(7, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(8, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
 
         buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,6 +80,7 @@ public class RobotContainer {
     }
 
     private void configureBindings() {
+        //Set up branch to add xbox commands
         buttonHelper.createButton(1, 0, new IntakeRollInCommand(intakeSubsystem, 0.45)
                 .alongWith(new ConeInCubeOutCommand(carriageSubsystem)), RunCondition.WHILE_HELD);
         buttonHelper.createButton(6, 0, new IntakeRollOutCommand(intakeSubsystem, IntakeConstants.INTAKE_OUT_SPEED)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,9 +10,6 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
-import edu.wpi.first.wpilibj2.command.button.POVButton;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.commands.ConeHandoffCommand;
 import frc.robot.commands.PoseWithVisionCommand;
 import frc.robot.commands.arm.DriverArmPositionCommand;
 import frc.robot.commands.carriage.ConeInCubeOutCommand;
@@ -32,6 +29,7 @@ import frc.robot.utils.controllerUtils.*;
 import frc.robot.utils.controllerUtils.MultiButton.RunCondition;
 
 import javax.inject.Inject;
+import java.util.Arrays;
 
 public class RobotContainer {
     public final ElevatorSubsystem elevatorSubsystem;
@@ -75,12 +73,15 @@ public class RobotContainer {
                         primaryController::getRightX,
                         elevatorSubsystem::getPosition
                 ));
-        configureBindings();
+        configureControllerOneBindings();
+        configureControllerTwo();
     }
 
-    private void configureBindings() {
+    private void configureControllerOneBindings() {
         //Set up branch to add xbox commands
         buttonHelper.setController(0);
+        buttonHelper.createButton(8, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
+                .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
         buttonHelper.createAxisButton(XboxController.Axis.kRightTrigger.value, 0, new IntakeRollInCommand(intakeSubsystem, 0.45)
                 .alongWith(new ConeInCubeOutCommand(carriageSubsystem)), RunCondition.WHILE_HELD, 0.25);
         buttonHelper.createAxisButton(XboxController.Axis.kLeftTrigger.value, 0, new IntakeRollOutCommand(intakeSubsystem, IntakeConstants.INTAKE_OUT_SPEED)
@@ -90,37 +91,41 @@ public class RobotContainer {
 
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new DriverArmPositionCommand(armSubsystem, elevatorSubsystem)
                 .beforeStarting(new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem).unless(elevatorSubsystem::isDown)), RunCondition.WHEN_PRESSED);
+    }
+
+    private void configureControllerTwo() {
 
         buttonHelper.setController(1);
-        buttonHelper.createAxisButton(XboxController.Axis.kLeftTrigger.value , 0, new IntakeShootMidCommand(intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
-                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED, 0.25);
+        buttonHelper.createButton(7, 0, new IntakeShootMidCommand(intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
+                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
 
-        buttonHelper.createAxisButton(XboxController.Axis.kRightTrigger.value , 0, new IntakeShootHighCommand(
+        buttonHelper.createButton(8 , 0, new IntakeShootHighCommand(
                 intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
-                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED, 0.25);
+                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
+
 
         buttonHelper.createButton(2, 0, new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
-        buttonHelper.createButton(7, 0, new CycleElevatorPositionCommand(elevatorSubsystem, armSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new IntakeShootLowCommand(intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
                 () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, armSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kX.value, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
-        buttonHelper.createButton(8, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
 
-        buttonHelper.createButton(XboxController.Button.kStart.value, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
+        buttonHelper.createButton(10, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
 
         buttonHelper.createButton(XboxController.Button.kA.value, 0, new ToggleCarriagePositionCommand(carriageSubsystem, elevatorSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
 
 
-        buttonHelper.createPOVButton(0, POVDirections.RIGHT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);
+        buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.UP, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.DOWN, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
-        buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.LEFT), RunCondition.WHEN_PRESSED);
+        buttonHelper.createPOVButton(0, POVDirections.RIGHT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.LEFT), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kA.value, 1, new ChuteAlignCommand(drivetrainSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftX, AutoConstants.ALIGNMENT_POSITION.SINGLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.LEFT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.RIGHT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
+
+
     }
 
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,7 +80,7 @@ public class RobotContainer {
     private void configureControllerOneBindings() {
         //Set up branch to add xbox commands
         buttonHelper.setController(0);
-        buttonHelper.createButton(8, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
+        buttonHelper.createButton(XboxController.Button.kStart.value, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
@@ -94,10 +94,10 @@ public class RobotContainer {
         buttonHelper.setController(1);
 
 
-        buttonHelper.createButton(2, 0, new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
+        buttonHelper.createButton(8, 0, new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, armSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
-        buttonHelper.createButton(XboxController.Button.kX.value, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
+        buttonHelper.createButton(7, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(10, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,17 +11,14 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import frc.robot.commands.PoseWithVisionCommand;
-import frc.robot.commands.arm.DriverArmPositionCommand;
 import frc.robot.commands.carriage.ConeInCubeOutCommand;
 import frc.robot.commands.carriage.ConeOutCubeInCommand;
 import frc.robot.commands.carriage.ToggleCarriagePositionCommand;
 import frc.robot.commands.drive.*;
 import frc.robot.commands.elevator.CycleElevatorPositionCommand;
 import frc.robot.commands.elevator.SetElevatorDownCommand;
-import frc.robot.commands.intake.*;
 import frc.robot.commands.led.PieceLEDCommand;
 import frc.robot.constants.AutoConstants;
-import frc.robot.constants.IntakeConstants;
 import frc.robot.di.RobotComponent;
 import frc.robot.subsystems.*;
 import frc.robot.subsystems.drivetrain.DrivetrainSubsystem;
@@ -29,7 +26,6 @@ import frc.robot.utils.controllerUtils.*;
 import frc.robot.utils.controllerUtils.MultiButton.RunCondition;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 
 public class RobotContainer {
     public final ElevatorSubsystem elevatorSubsystem;
@@ -73,25 +69,27 @@ public class RobotContainer {
                         primaryController::getRightX,
                         elevatorSubsystem::getPosition
                 ));
-        configureControllerOneBindings();
+        configureControllerOne();
         configureControllerTwo();
     }
 
-    private void configureControllerOneBindings() {
+    private void configureControllerOne() {
         //Set up branch to add xbox commands
         buttonHelper.setController(0);
 
+        buttonHelper.createButton(XboxController.Button.kStart.value, 0, new PoseWithVisionCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
+        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
-        buttonHelper.createButton(XboxController.Button.kX.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(XboxController.Button.kA.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
+        buttonHelper.createButton(XboxController.Button.kX.value, 0, new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
     }
 
     private void configureControllerTwo() {
-
         buttonHelper.setController(1);
 
-        buttonHelper.createButton(2, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
         buttonHelper.createButton(1, 0, new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
@@ -105,7 +103,6 @@ public class RobotContainer {
         buttonHelper.createButton(7, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
         buttonHelper.createButton(8, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
-
         buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.UP, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.DOWN, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
@@ -113,8 +110,6 @@ public class RobotContainer {
         buttonHelper.createButton(XboxController.Button.kA.value, 1, new ChuteAlignCommand(drivetrainSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftX, AutoConstants.ALIGNMENT_POSITION.SINGLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.LEFT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.RIGHT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
-
-
     }
 
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -82,39 +82,27 @@ public class RobotContainer {
         buttonHelper.setController(0);
         buttonHelper.createButton(8, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
-        buttonHelper.createAxisButton(XboxController.Axis.kRightTrigger.value, 0, new IntakeRollInCommand(intakeSubsystem, 0.45)
-                .alongWith(new ConeInCubeOutCommand(carriageSubsystem)), RunCondition.WHILE_HELD, 0.25);
-        buttonHelper.createAxisButton(XboxController.Axis.kLeftTrigger.value, 0, new IntakeRollOutCommand(intakeSubsystem, IntakeConstants.INTAKE_OUT_SPEED)
-                .alongWith(new ConeOutCubeInCommand(carriageSubsystem)), RunCondition.WHILE_HELD, .25);
+        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
         buttonHelper.createButton(XboxController.Button.kX.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
-        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new DriverArmPositionCommand(armSubsystem, elevatorSubsystem)
-                .beforeStarting(new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem).unless(elevatorSubsystem::isDown)), RunCondition.WHEN_PRESSED);
     }
 
     private void configureControllerTwo() {
 
         buttonHelper.setController(1);
-        buttonHelper.createButton(7, 0, new IntakeShootMidCommand(intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
-                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
-
-        buttonHelper.createButton(8 , 0, new IntakeShootHighCommand(
-                intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
-                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
 
 
         buttonHelper.createButton(2, 0, new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
 
-        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new IntakeShootLowCommand(intakeSubsystem, armSubsystem, elevatorSubsystem).unless(
-                () -> !elevatorSubsystem.isDown()), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, armSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kX.value, 0, new PieceLEDCommand(ledSubsystem, elevatorSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(10, 0, new StartEndCommand(() -> buttonHelper.setAllLayers(1), () -> buttonHelper.setAllLayers(0))
                 .alongWith(new PoseWithVisionCommand(drivetrainSubsystem)), RunCondition.WHILE_HELD);
 
-        buttonHelper.createButton(XboxController.Button.kA.value, 0, new ToggleCarriagePositionCommand(carriageSubsystem, elevatorSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
+        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ToggleCarriagePositionCommand(carriageSubsystem, elevatorSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
 
 
         buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);

--- a/src/main/java/frc/robot/commands/ConeHandoffCommand.java
+++ b/src/main/java/frc/robot/commands/ConeHandoffCommand.java
@@ -20,9 +20,9 @@ public class ConeHandoffCommand extends SequentialCommandGroup {
             ElevatorSubsystem elevatorSubsystem,
             CarriageSubsystem carriageSubsystem) {
         addCommands(
-                new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.DOWN),
+                new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.DOWN),
                 new SetArmPositionCommand(armSubsystem, elevatorSubsystem, ArmConstants.ArmPositions.UP),
-                new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.CONE_HANDOFF)
+                new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.CONE_HANDOFF)
                         .alongWith(new WaitCommand(0.5)),
                 new SetArmPositionCommand(armSubsystem, elevatorSubsystem, ArmConstants.ArmPositions.HANDOFF)
                         .alongWith(new WaitCommand(1.0)),

--- a/src/main/java/frc/robot/commands/elevator/CycleElevatorPositionCommand.java
+++ b/src/main/java/frc/robot/commands/elevator/CycleElevatorPositionCommand.java
@@ -13,15 +13,13 @@ import frc.robot.subsystems.LEDSubsystem;
 
 public class CycleElevatorPositionCommand extends CommandBase {
     private final ElevatorSubsystem elevatorSubsystem;
-    private final ArmSubsystem armSubsystem;
     private final CarriageSubsystem carriageSubsystem;
 
     private ElevatorPositions position;
     private SetElevatorPositionCommand command;
 
-    public CycleElevatorPositionCommand(ElevatorSubsystem elevatorSubsystem, ArmSubsystem armSubsystem, CarriageSubsystem carriageSubsystem, LEDSubsystem ledSubsystem) {
+    public CycleElevatorPositionCommand(ElevatorSubsystem elevatorSubsystem, CarriageSubsystem carriageSubsystem, LEDSubsystem ledSubsystem) {
         this.elevatorSubsystem = elevatorSubsystem;
-        this.armSubsystem = armSubsystem;
         this.carriageSubsystem = carriageSubsystem;
 
         addRequirements(elevatorSubsystem, carriageSubsystem);
@@ -36,7 +34,7 @@ public class CycleElevatorPositionCommand extends CommandBase {
         } else {
             position = ElevatorPositions.LEVEL_TWO;
         }
-        new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, position).schedule();
+        new SetElevatorPositionCommand(elevatorSubsystem, position).schedule();
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/elevator/SetElevatorDownCommand.java
+++ b/src/main/java/frc/robot/commands/elevator/SetElevatorDownCommand.java
@@ -12,7 +12,7 @@ import frc.robot.subsystems.CarriageSubsystem;
 import frc.robot.subsystems.ElevatorSubsystem;
 
 public class SetElevatorDownCommand extends SequentialCommandGroup {
-    public SetElevatorDownCommand(ElevatorSubsystem elevatorSubsystem, ArmSubsystem armSubsystem, CarriageSubsystem carriageSubsystem) {
+    public SetElevatorDownCommand(ElevatorSubsystem elevatorSubsystem, CarriageSubsystem carriageSubsystem) {
 
         addRequirements(elevatorSubsystem);
         addCommands(

--- a/src/main/java/frc/robot/commands/elevator/SetElevatorPositionCommand.java
+++ b/src/main/java/frc/robot/commands/elevator/SetElevatorPositionCommand.java
@@ -8,12 +8,10 @@ import frc.robot.subsystems.ElevatorSubsystem;
 
 public class SetElevatorPositionCommand extends CommandBase {
     private final ElevatorSubsystem elevatorSubsystem;
-    private final ArmSubsystem armSubsystem;
     private final ElevatorPositions position;
 
-    public SetElevatorPositionCommand(ElevatorSubsystem elevatorSubsystem, ArmSubsystem armSubsystem, ElevatorPositions position) {
+    public SetElevatorPositionCommand(ElevatorSubsystem elevatorSubsystem, ElevatorPositions position) {
         this.elevatorSubsystem = elevatorSubsystem;
-        this.armSubsystem = armSubsystem;
         this.position = position;
 
         addRequirements(elevatorSubsystem);

--- a/src/main/java/frc/robot/constants/DriveConstants.java
+++ b/src/main/java/frc/robot/constants/DriveConstants.java
@@ -29,28 +29,28 @@ public class DriveConstants {
     public static final int FRONT_LEFT_AZIMUTH = 1;
     public static final int FRONT_LEFT_ENCODER = 1;
     public static final boolean FRONT_LEFT_DRIVE_REVERSED = true;
-    public static final double FRONT_LEFT_ENCODER_OFFSET = -18.457;
+    public static final double FRONT_LEFT_ENCODER_OFFSET = -22.939 ;
     public static final boolean FRONT_LEFT_ENCODER_REVERSED = false;
 
     public static final int FRONT_RIGHT_DRIVE = 4;
     public static final int FRONT_RIGHT_AZIMUTH = 3;
     public static final int FRONT_RIGHT_ENCODER = 2;
     public static final boolean FRONT_RIGHT_DRIVE_REVERSED = false;
-    public static final double FRONT_RIGHT_ENCODER_OFFSET = 127.881;
+    public static final double FRONT_RIGHT_ENCODER_OFFSET = 67.236;
     public static final boolean FRONT_RIGHT_ENCODER_REVERSED = false;
 
     public static final int BACK_LEFT_DRIVE = 8;
     public static final int BACK_LEFT_AZIMUTH = 7;
     public static final int BACK_LEFT_ENCODER = 4;
     public static final boolean BACK_LEFT_DRIVE_REVERSED = true;
-    public static final double BACK_LEFT_ENCODER_OFFSET = -350.596;
+    public static final double BACK_LEFT_ENCODER_OFFSET = 22.5;
     public static final boolean BACK_LEFT_ENCODER_REVERSED = false;
 
     public static final int BACK_RIGHT_DRIVE = 6;
     public static final int BACK_RIGHT_AZIMUTH = 5;
     public static final int BACK_RIGHT_ENCODER = 3;
     public static final boolean BACK_RIGHT_DRIVE_REVERSED = false;
-    public static final double BACK_RIGHT_ENCODER_OFFSET = 131.836;
+    public static final double BACK_RIGHT_ENCODER_OFFSET = -34.541;
     public static final boolean BACK_RIGHT_ENCODER_REVERSED = false;
 
     public static final String FRONT_LEFT_MODULE_NAME = "front left";

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -38,14 +38,14 @@ public final class ElevatorConstants {
 
     public static final double ELEVATOR_P = 0.07;
     public static final double ELEVATOR_I = 0.00;
-    public static final double ELEVATOR_D = 0.03;
+    public static final double ELEVATOR_D = 0.02;
     public static final double ELEVATOR_F = 0.00;
-    public static final double GRAVITY_FEEDFORWARD = 0.05; //experimental value
+    public static final double GRAVITY_FEEDFORWARD = 0.03; //experimental value
 
     public static final double MAX_VELOCITY = 14 / ELEVATOR_DISTANCE_PER_PULSE;
     public static final double MAX_ACCEL = MAX_VELOCITY / 1.25;
 
-    public static final double ELEVATOR_TOLERANCE = 0.5 / ELEVATOR_DISTANCE_PER_PULSE;
+    public static final double ELEVATOR_TOLERANCE = 0.75 / ELEVATOR_DISTANCE_PER_PULSE;
 
     public static final double ELEVATOR_REVERSE_SOFT_LIMIT = 0 / ELEVATOR_DISTANCE_PER_PULSE;
     public static final double ELEVATOR_FORWARD_SOFT_LIMIT = STAGE_EXTENSION / ELEVATOR_DISTANCE_PER_PULSE;

--- a/src/main/java/frc/robot/constants/OIConstants.java
+++ b/src/main/java/frc/robot/constants/OIConstants.java
@@ -11,7 +11,7 @@ public final class OIConstants {
             1, ControllerType.XBOX
     );
     public static final int CONTROLLER_COUNT = CONTROLLERS.size(); //placeholder value
-    public static final double DEADBAND = 0.1;
+    public static final double DEADBAND = 0.15;
     public static final String TRANSLATION_XSUPPLIER = "translationXSupplier";
     public static final String TRANSLATION_YSUPPLIER = "translationYSupplier";
     public static final String THETA_SUPPLIER = "thetaSupplier";

--- a/src/main/java/frc/robot/constants/OIConstants.java
+++ b/src/main/java/frc/robot/constants/OIConstants.java
@@ -11,7 +11,7 @@ public final class OIConstants {
             1, ControllerType.XBOX
     );
     public static final int CONTROLLER_COUNT = CONTROLLERS.size(); //placeholder value
-    public static final double DEADBAND = 0.05;
+    public static final double DEADBAND = 0.1;
     public static final String TRANSLATION_XSUPPLIER = "translationXSupplier";
     public static final String TRANSLATION_YSUPPLIER = "translationYSupplier";
     public static final String THETA_SUPPLIER = "thetaSupplier";

--- a/src/main/java/frc/robot/constants/OIConstants.java
+++ b/src/main/java/frc/robot/constants/OIConstants.java
@@ -7,7 +7,8 @@ public final class OIConstants {
         Map of controllers using the port number as the key to the ControllerType
      */
     public static final Map<Integer, ControllerType> CONTROLLERS = Map.of(
-            0, ControllerType.CUSTOM
+            0, ControllerType.XBOX,
+            1, ControllerType.XBOX
     );
     public static final int CONTROLLER_COUNT = CONTROLLERS.size(); //placeholder value
     public static final double DEADBAND = 0.05;

--- a/src/main/java/frc/robot/di/RobotModule.java
+++ b/src/main/java/frc/robot/di/RobotModule.java
@@ -107,12 +107,12 @@ public class RobotModule {
         }, elevatorSubsystem));
         eventMap.put("elevatorStop", Commands.runOnce(elevatorSubsystem::stop, elevatorSubsystem));
         eventMap.put("elevatorDown", Commands.sequence(
-                new SetElevatorDownCommand(elevatorSubsystem, armSubsystem, carriageSubsystem),
+                new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem),
                 new WaitCommand(1.0),
                 new InstantCommand(elevatorSubsystem::stop, elevatorSubsystem)
         ));
-        eventMap.put("elevatorMid", new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.LEVEL_TWO));
-        eventMap.put("elevatorHigh", new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.UP));
+        eventMap.put("elevatorMid", new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.LEVEL_TWO));
+        eventMap.put("elevatorHigh", new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.UP));
         eventMap.put("carriageOut", new ConeOutCubeInCommand(carriageSubsystem).withTimeout(0.50));
         eventMap.put("flipCarriageOut", new CarriageFlipOutCommand(carriageSubsystem));
         eventMap.put("coneHigh", Commands.sequence(
@@ -120,7 +120,7 @@ public class RobotModule {
                         .alongWith(
                                 new InstantCommand(() -> carriageSubsystem.coneInCubeOut()),
                                 new WaitCommand(1),
-                                new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.UP)
+                                new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.UP)
                         ),
                 new WaitCommand(0.2),
                 new ConeOutCubeInCommand(carriageSubsystem).withTimeout(0.2)
@@ -129,7 +129,7 @@ public class RobotModule {
                 new CarriageFlipOutCommand(carriageSubsystem)
                         .alongWith(
                                 new WaitCommand(0.1),
-                                new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.LEVEL_TWO)),
+                                new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.LEVEL_TWO)),
                 new WaitCommand(0.3),
                 new ConeOutCubeInCommand(carriageSubsystem).withTimeout(0.2)
         ));
@@ -138,7 +138,7 @@ public class RobotModule {
                         .alongWith(
                                 new InstantCommand(() -> carriageSubsystem.coneOutCubeIn()),
                                 new WaitCommand(0.6),
-                                new SetElevatorPositionCommand(elevatorSubsystem, armSubsystem, ElevatorConstants.ElevatorPositions.UP)
+                                new SetElevatorPositionCommand(elevatorSubsystem, ElevatorConstants.ElevatorPositions.UP)
                         ),
                 new WaitCommand(0.0),
                 new ConeInCubeOutCommand(carriageSubsystem).withTimeout(0.6)

--- a/src/main/java/frc/robot/utils/Limelight.java
+++ b/src/main/java/frc/robot/utils/Limelight.java
@@ -147,6 +147,6 @@ public class Limelight {
             table = NetworkTableInstance.getDefault();
         }
 
-        return table.getTable("limelight-yeti").getEntry(key);
+        return table.getTable("limelight-kdos").getEntry(key);
     }
 }

--- a/src/main/java/frc/robot/utils/controllerUtils/ButtonHelper.java
+++ b/src/main/java/frc/robot/utils/controllerUtils/ButtonHelper.java
@@ -133,9 +133,11 @@ public class ButtonHelper {
             Command command,
             MultiButton.RunCondition runCondition) {
 
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
 
         return createButton(
-                () -> controller.getRawButton(buttonPort),
+                () -> activeController.getRawButton(buttonPort),
                 getButtonID(buttonPort),
                 layer,
                 command,
@@ -172,11 +174,15 @@ public class ButtonHelper {
             Command command,
             MultiButton.RunCondition runCondition,
             double threshold) {
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
         BooleanSupplier axisSupplier = () -> {
             if (threshold < 0.0) {
-                return controller.getRawAxis(axisPort) < threshold;
+                return activeController.getRawAxis(axisPort) < threshold;
             }
-            return controller.getRawAxis(axisPort) > threshold;
+            return activeController.getRawAxis(axisPort) > threshold;
         };
 
         return createButton(
@@ -198,11 +204,15 @@ public class ButtonHelper {
     public MultiButton createAxisButton(
             int axisPort,
             double threshold) {
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
         BooleanSupplier axisSupplier = () -> {
             if (threshold < 0.0) {
-                return controller.getRawAxis(axisPort) < threshold;
+                return activeController.getRawAxis(axisPort) < threshold;
             }
-            return controller.getRawAxis(axisPort) > threshold;
+            return activeController.getRawAxis(axisPort) > threshold;
         };
 
         return createButton(
@@ -226,7 +236,11 @@ public class ButtonHelper {
             int layer,
             Command command,
             MultiButton.RunCondition runCondition) {
-        BooleanSupplier povSupplier = () -> controller.getPOV(povPort) == direction.value;
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
+        BooleanSupplier povSupplier = () -> activeController.getPOV(povPort) == direction.value;
 
         return createButton(
                 povSupplier,
@@ -247,7 +261,11 @@ public class ButtonHelper {
     public MultiButton createPOVButton(
             int povPort,
             POVDirections direction) {
-        BooleanSupplier povSupplier = () -> controller.getPOV(povPort) == direction.value;
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
+        BooleanSupplier povSupplier = () -> activeController.getPOV(povPort) == direction.value;
 
         return createButton(
                 povSupplier,

--- a/src/main/java/frc/robot/utils/controllerUtils/ControllerContainer.java
+++ b/src/main/java/frc/robot/utils/controllerUtils/ControllerContainer.java
@@ -78,7 +78,7 @@ public class ControllerContainer {
 
         @Override
         public double getRightX() {
-            return super.getRawAxis(XboxController.Axis.kRightX.value);
+            return -super.getRawAxis(XboxController.Axis.kRightX.value);
         }
     }
 }

--- a/src/main/java/frc/robot/utils/controllerUtils/ControllerContainer.java
+++ b/src/main/java/frc/robot/utils/controllerUtils/ControllerContainer.java
@@ -37,7 +37,7 @@ public class ControllerContainer {
 
         @Override
         public double getLeftY() {
-            return -super.getRawAxis(0);
+            return super.getRawAxis(0);
         }
 
         @Override
@@ -68,7 +68,7 @@ public class ControllerContainer {
 
         @Override
         public double getLeftX() {
-            return super.getRawAxis(XboxController.Axis.kLeftX.value);
+            return -super.getRawAxis(XboxController.Axis.kLeftX.value);
         }
 
         @Override


### PR DESCRIPTION
Bug: When binding buttons for multiple controllers, only the controller that was last set by the ButtonHelper would work. The BooleanSupplier that is made for the button was referring to the currently active controller in the ButtonHelper. 

Fix: Captures the active controller at the time of making a button for the BooleanSupplier to reference.