### PR TITLE
Multiple Controller Fix

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,17 +11,14 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import frc.robot.commands.PoseWithVisionCommand;
-import frc.robot.commands.arm.DriverArmPositionCommand;
 import frc.robot.commands.carriage.ConeInCubeOutCommand;
 import frc.robot.commands.carriage.ConeOutCubeInCommand;
 import frc.robot.commands.carriage.ToggleCarriagePositionCommand;
 import frc.robot.commands.drive.*;
 import frc.robot.commands.elevator.CycleElevatorPositionCommand;
 import frc.robot.commands.elevator.SetElevatorDownCommand;
-import frc.robot.commands.intake.*;
 import frc.robot.commands.led.PieceLEDCommand;
 import frc.robot.constants.AutoConstants;
-import frc.robot.constants.IntakeConstants;
 import frc.robot.di.RobotComponent;
 import frc.robot.subsystems.*;
 import frc.robot.subsystems.drivetrain.DrivetrainSubsystem;
@@ -29,7 +26,6 @@ import frc.robot.utils.controllerUtils.*;
 import frc.robot.utils.controllerUtils.MultiButton.RunCondition;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 
 public class RobotContainer {
     public final ElevatorSubsystem elevatorSubsystem;
@@ -73,25 +69,27 @@ public class RobotContainer {
                         primaryController::getRightX,
                         elevatorSubsystem::getPosition
                 ));
-        configureControllerOneBindings();
+        configureControllerOne();
         configureControllerTwo();
     }
 
-    private void configureControllerOneBindings() {
+    private void configureControllerOne() {
         //Set up branch to add xbox commands
         buttonHelper.setController(0);
 
+        buttonHelper.createButton(XboxController.Button.kStart.value, 0, new PoseWithVisionCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
+        buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
-        buttonHelper.createButton(XboxController.Button.kX.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
+        buttonHelper.createButton(XboxController.Button.kA.value, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
 
+        buttonHelper.createButton(XboxController.Button.kX.value, 0, new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
     }
 
     private void configureControllerTwo() {
-
         buttonHelper.setController(1);
 
-        buttonHelper.createButton(2, 0, new SwerveLockCommand(drivetrainSubsystem), RunCondition.WHILE_HELD);
         buttonHelper.createButton(1, 0, new SetElevatorDownCommand(elevatorSubsystem, carriageSubsystem), RunCondition.WHEN_PRESSED);
 
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 0,new CycleElevatorPositionCommand(elevatorSubsystem, carriageSubsystem, ledSubsystem), RunCondition.WHEN_PRESSED);
@@ -105,7 +103,6 @@ public class RobotContainer {
         buttonHelper.createButton(7, 0, new ConeInCubeOutCommand(carriageSubsystem), RunCondition.WHILE_HELD);
         buttonHelper.createButton(8, 0, new ConeOutCubeInCommand(carriageSubsystem), RunCondition.WHILE_HELD);
 
-
         buttonHelper.createPOVButton(0, POVDirections.LEFT,1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.RIGHT), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.UP, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
         buttonHelper.createPOVButton(0,POVDirections.DOWN, 1, new GridAlignCommand(drivetrainSubsystem, carriageSubsystem, ledSubsystem, autoBuilder, AutoConstants.ALIGNMENT_POSITION.MIDDLE), RunCondition.WHEN_PRESSED);
@@ -113,8 +110,6 @@ public class RobotContainer {
         buttonHelper.createButton(XboxController.Button.kA.value, 1, new ChuteAlignCommand(drivetrainSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftX, AutoConstants.ALIGNMENT_POSITION.SINGLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kLeftBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.LEFT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
         buttonHelper.createButton(XboxController.Button.kRightBumper.value, 1, new DoubleStationAlignCommand(drivetrainSubsystem, elevatorSubsystem, ledSubsystem, carriageSubsystem, primaryController::getLeftY, AutoConstants.ALIGNMENT_POSITION.RIGHT_DOUBLE_STATION), RunCondition.WHEN_PRESSED);
-
-
     }
 
 

--- a/src/main/java/frc/robot/utils/controllerUtils/ButtonHelper.java
+++ b/src/main/java/frc/robot/utils/controllerUtils/ButtonHelper.java
@@ -133,9 +133,11 @@ public class ButtonHelper {
             Command command,
             MultiButton.RunCondition runCondition) {
 
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
 
         return createButton(
-                () -> controller.getRawButton(buttonPort),
+                () -> activeController.getRawButton(buttonPort),
                 getButtonID(buttonPort),
                 layer,
                 command,
@@ -172,11 +174,15 @@ public class ButtonHelper {
             Command command,
             MultiButton.RunCondition runCondition,
             double threshold) {
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
         BooleanSupplier axisSupplier = () -> {
             if (threshold < 0.0) {
-                return controller.getRawAxis(axisPort) < threshold;
+                return activeController.getRawAxis(axisPort) < threshold;
             }
-            return controller.getRawAxis(axisPort) > threshold;
+            return activeController.getRawAxis(axisPort) > threshold;
         };
 
         return createButton(
@@ -198,11 +204,15 @@ public class ButtonHelper {
     public MultiButton createAxisButton(
             int axisPort,
             double threshold) {
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
         BooleanSupplier axisSupplier = () -> {
             if (threshold < 0.0) {
-                return controller.getRawAxis(axisPort) < threshold;
+                return activeController.getRawAxis(axisPort) < threshold;
             }
-            return controller.getRawAxis(axisPort) > threshold;
+            return activeController.getRawAxis(axisPort) > threshold;
         };
 
         return createButton(
@@ -226,7 +236,11 @@ public class ButtonHelper {
             int layer,
             Command command,
             MultiButton.RunCondition runCondition) {
-        BooleanSupplier povSupplier = () -> controller.getPOV(povPort) == direction.value;
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
+        BooleanSupplier povSupplier = () -> activeController.getPOV(povPort) == direction.value;
 
         return createButton(
                 povSupplier,
@@ -247,7 +261,11 @@ public class ButtonHelper {
     public MultiButton createPOVButton(
             int povPort,
             POVDirections direction) {
-        BooleanSupplier povSupplier = () -> controller.getPOV(povPort) == direction.value;
+
+        // Captures controller that is used at the time of the button's creation
+        Controller activeController = controller;
+
+        BooleanSupplier povSupplier = () -> activeController.getPOV(povPort) == direction.value;
 
         return createButton(
                 povSupplier,


### PR DESCRIPTION
Bug: When binding buttons for multiple controllers, only the controller that was last set by the ButtonHelper would work. The BooleanSupplier that is made for the button was referring to the currently active controller in the ButtonHelper.

Fix: Captures the active controller at the time of making a button for the BooleanSupplier to reference.